### PR TITLE
[DV-8391] Added ResponseStream to VerboseErrorHttpClient::stream.

### DIFF
--- a/src/HttpClient/Response/VerboseErrorResponse.php
+++ b/src/HttpClient/Response/VerboseErrorResponse.php
@@ -8,12 +8,12 @@ use Generator;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\ClientException;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\RedirectionException;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\ServerException;
-use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * Wraps a response to be able to decorate the thrown exceptions.
@@ -85,7 +85,7 @@ readonly class VerboseErrorResponse implements ResponseInterface
      *
      * @param iterable<VerboseErrorResponse> $responses
      *
-     * @return Generator<VerboseErrorResponse, ChunkInterface>
+     * @return Generator<VerboseErrorResponse, ResponseStreamInterface>
      */
     public static function stream(HttpClientInterface $client, iterable $responses, ?float $timeout): Generator
     {

--- a/src/HttpClient/Response/VerboseErrorResponse.php
+++ b/src/HttpClient/Response/VerboseErrorResponse.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Superbrave\VerboseErrorHttpClientBundle\HttpClient\Response;
 
+use Generator;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\ClientException;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\RedirectionException;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\ServerException;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -75,5 +78,19 @@ readonly class VerboseErrorResponse implements ResponseInterface
     public function cancel(): void
     {
         $this->response->cancel();
+    }
+
+    /**
+     * @internal
+     *
+     * @param iterable<VerboseErrorResponse> $responses
+     *
+     * @return Generator<VerboseErrorResponse, ChunkInterface>
+     */
+    public static function stream(HttpClientInterface $client, iterable $responses, ?float $timeout): Generator
+    {
+        foreach ($responses as $response) {
+            yield $response => $client->stream($response->response, $timeout);
+        }
     }
 }

--- a/src/HttpClient/VerboseErrorHttpClient.php
+++ b/src/HttpClient/VerboseErrorHttpClient.php
@@ -28,7 +28,10 @@ class VerboseErrorHttpClient implements HttpClientInterface
         return new VerboseErrorResponse($response);
     }
 
-    public function stream($responses, ?float $timeout = null): ResponseStreamInterface
+    /**
+     * @param VerboseErrorResponse|iterable $responses
+     */
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
     {
         if ($responses instanceof VerboseErrorResponse) {
             $responses = [$responses];

--- a/src/HttpClient/VerboseErrorHttpClient.php
+++ b/src/HttpClient/VerboseErrorHttpClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Superbrave\VerboseErrorHttpClientBundle\HttpClient;
 
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Response\VerboseErrorResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -29,7 +30,11 @@ class VerboseErrorHttpClient implements HttpClientInterface
 
     public function stream($responses, ?float $timeout = null): ResponseStreamInterface
     {
-        return $this->client->stream($responses, $timeout);
+        if ($responses instanceof VerboseErrorResponse) {
+            $responses = [$responses];
+        }
+
+        return new ResponseStream(VerboseErrorResponse::stream($this->client, $responses, $timeout));
     }
 
     public function withOptions(array $options): static


### PR DESCRIPTION
| Q | A
| - | -
| ⏱ Review tijd | 10 min <!-- 5 min -->
| ⌨️ Type wijziging | New feature <!-- 🛠 Bug fix / ➕ Nieuwe feature / 🗒 Docs / 🤷🏻‍♂️ Overige -->
| 🔗 Ticket | DV-8391 <!-- DV-1337 -->

### ✍️ Wijzigingen
<!-- Omschrijving van welke componenten er zijn gewijzigd en waarom. -->

### 🪜 Stappen om te testen
<!-- Omschrijving van de benodigde (technische) stappen om een testbare situatie te creëren en de verwachte uitkomst. -->
1. Install the changes in this branch: 
```
composer require superbrave/verbose-error-http-client:dev-DV-8391
```
2. Apply this git patch to the Supplier Service (pharmacy-service) and run the test:
```patch
Subject: [PATCH] VerboseErrorHttpClientTest
---
Index: tests/App/VerboseErrorHttpClientTest.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/tests/App/VerboseErrorHttpClientTest.php b/tests/App/VerboseErrorHttpClientTest.php
new file mode 100644
--- /dev/null	(date 1713537703108)
+++ b/tests/App/VerboseErrorHttpClientTest.php	(date 1713537703108)
@@ -0,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\SentryBundle\Tracing\HttpClient\TraceableHttpClient;
+use Sentry\State\HubInterface;
+use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Response\VerboseErrorResponse;
+use Superbrave\VerboseErrorHttpClientBundle\HttpClient\VerboseErrorHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class VerboseErrorHttpClientTest extends TestCase
+{
+    public function testVerboseErrorHttpClientStreamIsCompatibleWithSentryTraceableHttpClientStream(): void
+    {
+        // Arrange
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+
+        $sentryHttpClient = new TraceableHttpClient($httpClientMock, $this->createMock(HubInterface::class));
+
+        $verboseResponse = new VerboseErrorResponse(new MockResponse(''));
+
+        $verboseHttpClient = new VerboseErrorHttpClient($httpClientMock);
+
+        // Act
+        $response = $verboseHttpClient->stream($verboseResponse);
+
+        $sentryHttpClient->stream($response);
+
+        // Assert
+        $this->expectNotToPerformAssertions(); // Asserts that no errors have been raised in the act stage above
+    }
+}
```
