### PR TITLE
[DV-8391] Fixed VerboseErrorResponse::stream returns Chunk instead of a ResponseStream.

### DIFF
--- a/src/HttpClient/Response/VerboseErrorResponse.php
+++ b/src/HttpClient/Response/VerboseErrorResponse.php
@@ -8,12 +8,12 @@ use Generator;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\ClientException;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\RedirectionException;
 use Superbrave\VerboseErrorHttpClientBundle\HttpClient\Exception\ServerException;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
-use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * Wraps a response to be able to decorate the thrown exceptions.
@@ -85,12 +85,14 @@ readonly class VerboseErrorResponse implements ResponseInterface
      *
      * @param iterable<VerboseErrorResponse> $responses
      *
-     * @return Generator<VerboseErrorResponse, ResponseStreamInterface>
+     * @return Generator<ResponseInterface, ChunkInterface>
      */
     public static function stream(HttpClientInterface $client, iterable $responses, ?float $timeout): Generator
     {
         foreach ($responses as $response) {
-            yield $response => $client->stream($response->response, $timeout);
+            foreach ($client->stream($response->response, $timeout) as $innerResponse => $chunk) {
+                yield $innerResponse => $chunk;
+            }
         }
     }
 }

--- a/tests/Response/VerboseErrorResponseTest.php
+++ b/tests/Response/VerboseErrorResponseTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpClient\Exception\RedirectionException as SymfonyRedire
 use Symfony\Component\HttpClient\Exception\ServerException as SymfonyServerException;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class VerboseErrorResponseTest extends TestCase
@@ -203,6 +204,25 @@ final class VerboseErrorResponseTest extends TestCase
             ->method('cancel');
 
         $this->response->cancel();
+    }
+
+    public function testStreamCallsInnerHttpClientStreamWithInnerResponse(): void
+    {
+        // Arrange
+        $timeout = 50.5;
+        $innerHttpClientMock = $this->createMock(HttpClientInterface::class);
+
+        $innerResponseMock = $this->createMock(ResponseInterface::class);
+        $verboseErrorResponse = new VerboseErrorResponse($innerResponseMock);
+
+        // Assert
+        $innerHttpClientMock->expects(self::once())
+            ->method('stream')
+            ->with($innerResponseMock, $timeout);
+
+        // Act
+        $stream = VerboseErrorResponse::stream($innerHttpClientMock, [$verboseErrorResponse], $timeout);
+        $stream->next();
     }
 
     public static function provideExceptionTestCases(): array


### PR DESCRIPTION
| Q | A
| - | -
| ⏱ Review tijd | 5 min <!-- 5 min -->
| ⌨️ Type wijziging | Bug fix <!-- 🛠 Bug fix / ➕ Nieuwe feature / 🗒 Docs / 🤷🏻‍♂️ Overige -->
| 🔗 Ticket | DV-8391 <!-- DV-1337 -->

### ✍️ Wijzigingen
<!-- Omschrijving van welke componenten er zijn gewijzigd en waarom. -->
While working with https://github.com/superbrave/pharmacy-service/pull/760 it turned out that the Sentry `TracableHttpClient` was not compatible with a `ResponseStreamInterface` but needed a `ChunkInterface` as a return value.

### 🪜 Stappen om te testen
<!-- Omschrijving van de benodigde (technische) stappen om een testbare situatie te creëren en de verwachte uitkomst. -->
You could use https://github.com/superbrave/pharmacy-service/pull/760 and download a prescription from the front-end.
