### PR TITLE
[DV-8395] Made bundle compatible with Symfony 6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     "require": {
         "php": "^8.2",
         "symfony/http-client-contracts": "^3.4",
-        "symfony/dependency-injection": "^6.4|^7.0",
-        "symfony/framework-bundle": "^6.4|^7.0"
+        "symfony/dependency-injection": "^6.3|^7.0",
+        "symfony/framework-bundle": "^6.3|^7.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "friendsofphp/php-cs-fixer": "^3.54",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.6",
-        "symfony/http-client": "^6.4|^7.0"
+        "symfony/http-client": "^6.3|^7.0"
     },
     "suggest": {
         "symfony/http-client": "This package requires an actual Symfony HTTP client implementation to decorate."


### PR DESCRIPTION
| Q | A
| - | -
| ⏱ Review tijd | 5 min <!-- 5 min -->
| ⌨️ Type wijziging | Other <!-- 🛠 Bug fix / ➕ Nieuwe feature / 🗒 Docs / 🤷🏻‍♂️ Overige -->
| 🔗 Ticket | DV-8395 <!-- DV-1337 -->

### ✍️ Wijzigingen
<!-- Omschrijving van welke componenten er zijn gewijzigd en waarom. -->
The Consult System still runs Symfony 6.3. We need this package to be compatible.

### 🪜 Stappen om te testen
<!-- Omschrijving van de benodigde (technische) stappen om een testbare situatie te creëren en de verwachte uitkomst. -->
1. `composer require superbrave/verbose-error-http-client:dev-DV-8395` in the Consult System. 
2. See that this succeeds now.
